### PR TITLE
Fix for saving (respectively retrieving) values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+
+*.cpp__

--- a/.gitignore
+++ b/.gitignore
@@ -261,4 +261,4 @@ __pycache__/
 *.pyc
 
 
-*.cpp__
+tmp/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ConfigTool
-ESP32 and ESP8266 Arduino library for easy saving and storing config variables.
-Also has a handler to edit them via a webserver (ESP8266 Only).
+ESP32 Arduino library for easy saving and storing config variables.
+
+TODO (port this to ESP32): Also has a handler to edit them via a webserver (ESP8266 Only).
 
 See [this example](https://github.com/Tvde1/ConfigTool/blob/master/examples/ConfigTool/ConfigTool.ino).

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ConfigTool
-version=1.0
+version=1.0.1
 author=Tvde1
 maintainer=gerdlanger
 sentence=Save config variable and edit them online.

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=ConfigTool
 version=1.0
 author=Tvde1
-maintainer=Tvde1
+maintainer=gerdlanger
 sentence=Save config variable and edit them online.
 paragraph=No more hardcoding. This library will save and load config variables and you can edit them at an endpoint you choose.
 category=Data Storage
-url=https://github.com/Tvde1/ConfigTool
+url=https://github.com/gerdlanger/ConfigTool
 includes=ConfigTool.h

--- a/src/ConfigTool.cpp
+++ b/src/ConfigTool.cpp
@@ -5,9 +5,7 @@
 
 #include "ConfigTool.h"
 #include <FS.h>
-#include <ArduinoJson.h>
 #include <SPIFFS.h>
-#include <map>
 
 void ConfigTool::load() {
 	if (!SPIFFS.begin(true)) {
@@ -21,7 +19,7 @@ void ConfigTool::load() {
 	DynamicJsonDocument root(ConfigSize);
 	deserializeJson(root, f.readStringUntil('\n'));
 	for (auto item : variables_) {
-		item.second->deserialize(root);
+		item.second->deserialize(&root);
 	}
 
 	f.close();
@@ -31,12 +29,13 @@ void ConfigTool::save() {
 	DynamicJsonDocument root(ConfigSize);
 
 	for (auto item : variables_) {
-		item.second->serialize(root);
+		item.second->serialize(&root);
 	}
-
-	SPIFFS.begin();
+	
+	SPIFFS.begin(true);
 	File f = SPIFFS.open("/config.json", "w");
 	serializeJson(root, f);
+	f.close();
 }
 
 void ConfigTool::reset() {

--- a/src/ConfigTool.h
+++ b/src/ConfigTool.h
@@ -5,15 +5,14 @@
 #ifndef _ConfigTool_h
 #define _ConfigTool_h
 
-#include <Arduino.h>
 #include <map>
 #include <ArduinoJson.h>
 
 
 struct BaseVar {
 	String name;
-	virtual void serialize(JsonDocument) = 0;
-	virtual void deserialize(JsonDocument) = 0;
+	virtual void serialize(JsonDocument*) = 0;
+	virtual void deserialize(JsonDocument*) = 0;
 	virtual void reset() = 0;
 	virtual String toString() = 0;
 	virtual void fromString(String) = 0;
@@ -23,9 +22,9 @@ template <typename T>
 struct ConfigVar : BaseVar {
 	ConfigVar(String n, T* p) {};
 
-	void deserialize(JsonDocument json) {};
+	void deserialize(JsonDocument* json) {};
 
-	void serialize(JsonDocument json) {};
+	void serialize(JsonDocument* json) {};
 
 	void reset() {};
 
@@ -44,12 +43,12 @@ struct ConfigVar<String> : BaseVar {
 		defaultValue = *p;
 	};
 
-	void deserialize(JsonDocument json) {
-		*pointer = String{ json[name] | defaultValue };
+	void deserialize(JsonDocument* json) {
+		*pointer = String{ (*json)[name] | defaultValue };
 	}
 
-	void serialize(JsonDocument json) {
-		json[name] = *pointer;
+	void serialize(JsonDocument* json) {
+		(*json)[name] = *pointer;
 	}
 
 	void reset() {
@@ -75,14 +74,14 @@ struct ConfigVar<bool> : BaseVar {
 		defaultValue = *p;
 	};
 
-	void deserialize(JsonDocument json) {
-		if (!json[name].isNull()) {
-			*pointer = json[name];
+	void deserialize(JsonDocument* json) {
+		if (!(*json)[name].isNull()) {
+			*pointer = (*json)[name];
 		}
 	}
 
-	void serialize(JsonDocument json) {
-		json[name] =  *pointer;
+	void serialize(JsonDocument* json) {
+		(*json)[name] =  *pointer;
 	}
 
 	void reset() {
@@ -108,14 +107,14 @@ struct ConfigVar<int> : BaseVar {
 		defaultValue = *p;
 	};
 
-	void deserialize(JsonDocument json) {
-		if (!json[name].isNull()) {
-			*pointer = json[name];
+	void deserialize(JsonDocument* json) {
+		if (!(*json)[name].isNull()) {
+			*pointer = (*json)[name];
 		}
 	}
 
-	void serialize(JsonDocument json) {
-		json[name] = *pointer;
+	void serialize(JsonDocument* json) {
+		(*json)[name] = *pointer;
 	}
 
 	void reset() {

--- a/test/ConfigToolTest/ConfigToolTest.ino
+++ b/test/ConfigToolTest/ConfigToolTest.ino
@@ -1,0 +1,110 @@
+/**
+ * Test functionality of ConfigTool.
+ * 
+ * TAKE CARE !!! This DELETES exisintg "/config.json" files !!!
+ * 
+ */
+
+
+#include <SPIFFS.h>
+#include <ConfigTool.h>
+
+String config_String_1 = "Default";
+String config_String_2 = "Test";
+int    config_int_1    = 100;
+int    config_int_2    = 200;
+bool   config_bool_F   = false;
+bool   config_bool_T   = true;
+
+ConfigTool configTool;
+
+bool dumpConfig(bool check){
+
+  File file = SPIFFS.open("/config.json");
+  if(!file){
+    Serial.println("reading - config failed");
+    return false;
+  }
+
+  Serial.println("reading - dumpfile:");
+  while(file.available()){
+    Serial.write(file.read());
+  }
+  Serial.println();
+  // if requested, print the comparison for "zeroVariables":
+  if (check) Serial.println("{\"String1\":\"-1-\",\"String2\":\"-2-\",\"bool__F\":false,\"bool__T\":false,\"int___1\":0,\"int___2\":0}");
+  
+  return true;
+}
+
+void initVariables() {
+  configTool.addVariable("String1", &config_String_1);
+  configTool.addVariable("String2", &config_String_2);
+  configTool.addVariable("int___1", &config_int_1);
+  configTool.addVariable("int___2", &config_int_2);
+  configTool.addVariable("bool__F", &config_bool_F);
+  configTool.addVariable("bool__T", &config_bool_T);
+}
+
+void zeroVariables() {
+  config_String_1 = "-1-";
+  config_String_2 = "-2-";
+  config_int_1    = 0;
+  config_int_2    = 0;
+  config_bool_F   = false;
+  config_bool_T   = false;
+}
+
+void checkDefaultValues() {
+  Serial.printf("String1 OK=%d\n", (config_String_1 == "Default"));
+  Serial.printf("String2 OK=%d\n", (config_String_2 == "Test"));
+  Serial.printf("int1    OK=%d\n", (config_int_1    == 100));
+  Serial.printf("int2    OK=%d\n", (config_int_2    == 200));
+  Serial.printf("bool_F  OK=%d\n", (config_bool_F   == false));
+  Serial.printf("bool_T  OK=%d\n", (config_bool_T   == true));
+}
+
+void setup(){
+  Serial.begin(115200);
+  Serial.println("Setup begin");
+  
+  if(!SPIFFS.begin(false)){
+    Serial.println("setup - SPIFFS begin failed");
+    return;
+  }
+
+  Serial.println("setup - dump at start");
+  dumpConfig(true);
+
+  Serial.println("setup - init variables to default and save");
+  initVariables();
+  configTool.save();
+  dumpConfig(false);
+
+  Serial.println("setup - manipulate variables and load again");
+  zeroVariables();
+  configTool.load();
+  checkDefaultValues();
+
+  Serial.println("setup - manipulate variables and save");
+  zeroVariables();
+  configTool.save();
+  dumpConfig(true);
+
+  Serial.println("setup - reset stored values");
+  configTool.reset();
+  dumpConfig(false);
+  checkDefaultValues();
+
+  Serial.println("setup - again manipulate variables and save");
+  zeroVariables();
+  configTool.save();
+  dumpConfig(true);
+
+  Serial.println( "Setup end" );
+  Serial.println( "Test complete" );
+}
+
+void loop(){
+  // NOP
+}


### PR DESCRIPTION
I like the adaption for ESP32 and newer JSON lib, but had some trouble in retrieving the values from the settings. To me it looks necessary to pass the JsonDocument as reference for serialize method.
For consistency I adopted the deserialize as well.

I noticed the problem while saving. The items passed to be serialized where not included in the JsonDocument. Not sure whether compiler settings might influence this. I'm using plain Arduino IDE 1.8.10 plus with integrated espressif tool chain.